### PR TITLE
Added 52 upstream qmk keymaps automatically

### DIFF
--- a/data/new_data.json
+++ b/data/new_data.json
@@ -1,0 +1,1262 @@
+{
+  "headers": [
+    "url",
+    "author",
+    "image",
+    "keyCount",
+    "firmware",
+    "keyboard",
+    "stagger",
+    "split",
+    "languages",
+    "summary",
+    "OS",
+    "writeup",
+    "hasLetterOnThumb",
+    "layerCount",
+    "imageDate",
+    "hasOuterPinkyColumns",
+    "hasExtraIndexColumns",
+    "hasVerticalCombos",
+    "hasHomeRowMods"
+  ],
+  "keymaps": [
+    {
+      "OS": [],
+      "author": "floookay",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://gist.githubusercontent.com/floookay/7bf6511a8d84804d32de4d7bbe3bd0fb/raw/dffd622a762463f341466ffecefad3b31ad3ee4f/layout.png",
+      "imageDate": "idk",
+      "keyCount": 82,
+      "keyboard": "Adelheid",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 2,
+      "split": false,
+      "stagger": "row",
+      "summary": "The default keymap for the Adelheid",
+      "url": "https://github.com/floookay/qmk_firmware/tree/master/keyboards/adelheid/keymaps/floookay",
+      "writeup": "https://github.com/floookay/qmk_firmware/tree/master/keyboards/adelheid/keymaps/floookay/readme.md"
+    },
+    {
+      "OS": [
+        "Windows"
+      ],
+      "author": "jetpacktuxedo",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/B9XraJY.jpg",
+      "imageDate": "idk",
+      "keyCount": 42,
+      "keyboard": "AMJ40",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "row",
+      "summary": "Jetpacktuxedo's AMJ40 layout",
+      "url": "https://github.com/jetpacktuxedo/qmk_firmware/tree/master/keyboards/amj40/keymaps/jetpacktuxedo",
+      "writeup": "https://github.com/jetpacktuxedo/qmk_firmware/tree/master/keyboards/amj40/keymaps/jetpacktuxedo/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "khitsule",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/wuki3aM.png",
+      "imageDate": "idk",
+      "keyCount": 42,
+      "keyboard": "Atreus",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "Atreus Layout by Khitsule",
+      "url": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/atreus/keymaps/khitsule",
+      "writeup": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/atreus/keymaps/khitsule/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "magicmonty",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "http://i.imgur.com/eEwjLEj.png",
+      "imageDate": "idk",
+      "keyCount": 66,
+      "keyboard": "Clueboard 66%",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 7,
+      "split": false,
+      "stagger": "row",
+      "summary": "Layout of @magicmonty",
+      "url": "https://github.com/magicmonty/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/magicmonty",
+      "writeup": "https://github.com/magicmonty/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/magicmonty/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "manofinterests",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "http://i.imgur.com/7Capi8W.png",
+      "imageDate": "idk",
+      "keyCount": 66,
+      "keyboard": "Clueboard 66%",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "row",
+      "summary": "![Clueboard Layout Image](http://i.imgur.com/7Capi8W.png)",
+      "url": "https://github.com/manofinterests/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/manofinterests",
+      "writeup": "https://github.com/manofinterests/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/manofinterests/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "smt",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "http://i.imgur.com/Ll5gGte.png",
+      "imageDate": "idk",
+      "keyCount": 66,
+      "keyboard": "Clueboard 66%",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "row",
+      "summary": "smt Clueboard Layout (HHKB variant)",
+      "url": "https://github.com/smt/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/smt",
+      "writeup": "https://github.com/smt/qmk_firmware/tree/master/keyboards/clueboard/66/keymaps/smt/readme.md"
+    },
+    {
+      "OS": [
+        "Windows",
+        "MacOS"
+      ],
+      "author": "alper",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/BvBYgpz.png",
+      "imageDate": "idk",
+      "keyCount": 47,
+      "keyboard": "Contra",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 6,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "Alper's Contra Layout",
+      "url": "https://github.com/alper/qmk_firmware/tree/master/keyboards/contra/keymaps/alper",
+      "writeup": "https://github.com/alper/qmk_firmware/tree/master/keyboards/contra/keymaps/alper/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "bingocaller",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/lFP2O41.png",
+      "imageDate": "idk",
+      "keyCount": 67,
+      "keyboard": "DZ60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 6,
+      "split": false,
+      "stagger": "row",
+      "summary": "MacOS standard 60% keymap with Vim-like arrows",
+      "url": "https://github.com/bingocaller/qmk_firmware/tree/master/keyboards/dz60/keymaps/bingocaller",
+      "writeup": "https://github.com/bingocaller/qmk_firmware/tree/master/keyboards/dz60/keymaps/bingocaller/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "LEdiodes",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/pDneawX.jpg",
+      "imageDate": "idk",
+      "keyCount": 67,
+      "keyboard": "DZ60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "row",
+      "summary": "LEdiodes Keymap for XD60 60% PCB",
+      "url": "https://github.com/LEdiodes/qmk_firmware/tree/master/keyboards/dz60/keymaps/LEdiodes",
+      "writeup": "https://github.com/LEdiodes/qmk_firmware/tree/master/keyboards/dz60/keymaps/LEdiodes/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "niclake",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/Lmw08LT.jpg",
+      "imageDate": "idk",
+      "keyCount": 67,
+      "keyboard": "DZ60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "row",
+      "summary": "Nic Lake's DZ60 Layout",
+      "url": "https://github.com/niclake/qmk_firmware/tree/master/keyboards/dz60/keymaps/niclake",
+      "writeup": "https://github.com/niclake/qmk_firmware/tree/master/keyboards/dz60/keymaps/niclake/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "tarnjotsingh",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/UV0t6aL.png",
+      "imageDate": "idk",
+      "keyCount": 62,
+      "keyboard": "DZ60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "row",
+      "summary": "DZ60 ISO Keymap",
+      "url": "https://github.com/tarnjotsingh/qmk_firmware/tree/master/keyboards/dz60/keymaps/tarnjotsingh",
+      "writeup": "https://github.com/tarnjotsingh/qmk_firmware/tree/master/keyboards/dz60/keymaps/tarnjotsingh/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "fsck",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/Sb8n8B0.png",
+      "imageDate": "idk",
+      "keyCount": 56,
+      "keyboard": "ECO",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 2,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![eco:fsck Layout Image](https://i.imgur.com/Sb8n8B0.png)",
+      "url": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/eco/keymaps/fsck",
+      "writeup": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/eco/keymaps/fsck/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "ifohancroft",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/vANNhro.png",
+      "imageDate": "idk",
+      "keyCount": 68,
+      "keyboard": "ErgoDash rev1.2",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "columnar",
+      "summary": "![IFo Hancroft ErgoDash Layout Image](https://i.imgur.com/vANNhro.png)",
+      "url": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/ergodash/rev1/keymaps/ifohancroft",
+      "writeup": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/ergodash/rev1/keymaps/ifohancroft/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "bpruitt-goddard",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/kVPmpFG.png",
+      "imageDate": "idk",
+      "keyCount": 76,
+      "keyboard": "ErgoDox EZ",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "Ergodox EZ Layout by bpruitt-goddard",
+      "url": "https://github.com/bpruitt-goddard/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/bpruitt-goddard",
+      "writeup": "https://github.com/bpruitt-goddard/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/bpruitt-goddard/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "nathanvercaemert",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": true,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/x6VgH9Z.png",
+      "imageDate": "idk",
+      "keyCount": 76,
+      "keyboard": "ErgoDox EZ",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 15,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "The nathanvercaemert ErgoDox EZ configuration",
+      "url": "https://github.com/nathanvercaemert/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/nathanvercaemert",
+      "writeup": "https://github.com/nathanvercaemert/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/nathanvercaemert/readme.md"
+    },
+    {
+      "OS": [
+        "Windows",
+        "MacOS"
+      ],
+      "author": "nfriend",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/CMMmdBc.png",
+      "imageDate": "idk",
+      "keyCount": 76,
+      "keyboard": "ErgoDox EZ",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 12,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "[nfriend](https://gitlab.com/nfriend)'s ErgoDox EZ configuration",
+      "url": "https://github.com/nfriend/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/nfriend",
+      "writeup": "https://github.com/nfriend/qmk_firmware/tree/master/keyboards/ergodox_ez/keymaps/nfriend/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "abstractkb",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://4.bp.blogspot.com/-889nMXxgSM0/XCNxwnO5kUI/AAAAAAAA6mI/tZbWgZVCBW0dyZOCGJDkjN06DVax7j8XwCLcBGAs/s1600/48422820_967732713413298_485744639215665152_n.jpg",
+      "imageDate": "idk",
+      "keyCount": 50,
+      "keyboard": "Gergo",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "[Gergo! By g Heavy Industries](http://gboards.ca)",
+      "url": "https://github.com/abstractkb/qmk_firmware/tree/master/keyboards/gergo/keymaps/abstractkb",
+      "writeup": "https://github.com/abstractkb/qmk_firmware/tree/master/keyboards/gergo/keymaps/abstractkb/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "germ",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://4.bp.blogspot.com/-889nMXxgSM0/XCNxwnO5kUI/AAAAAAAA6mI/tZbWgZVCBW0dyZOCGJDkjN06DVax7j8XwCLcBGAs/s1600/48422820_967732713413298_485744639215665152_n.jpg",
+      "imageDate": "idk",
+      "keyCount": 50,
+      "keyboard": "Gergo",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "[Gergo! By g Heavy Industries](http://gboards.ca)",
+      "url": "https://github.com/germ/qmk_firmware/tree/master/keyboards/gergo/keymaps/germ",
+      "writeup": "https://github.com/germ/qmk_firmware/tree/master/keyboards/gergo/keymaps/germ/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "abhixec",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/Eqp8hov.jpg",
+      "imageDate": "idk",
+      "keyCount": 62,
+      "keyboard": "GH60 Satan",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "row",
+      "summary": "default Satan GH60 layout",
+      "url": "https://github.com/abhixec/qmk_firmware/tree/master/keyboards/gh60/satan/keymaps/abhixec",
+      "writeup": "https://github.com/abhixec/qmk_firmware/tree/master/keyboards/gh60/satan/keymaps/abhixec/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "stickandgum",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://user-images.githubusercontent.com/22257588/130371838-875ba65b-88ea-4f81-a44a-bb24194c4989.png",
+      "imageDate": "idk",
+      "keyCount": 83,
+      "keyboard": "GMMK Pro (ANSI)",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 2,
+      "split": false,
+      "stagger": "row",
+      "summary": "Glorious GMMK Pro / ANSI - Enhanced Keyboard",
+      "url": "https://github.com/stickandgum/qmk_firmware/tree/master/keyboards/gmmk/pro/ansi/keymaps/stickandgum",
+      "writeup": "https://github.com/stickandgum/qmk_firmware/tree/master/keyboards/gmmk/pro/ansi/keymaps/stickandgum/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "ifohancroft",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/ml1olw4.png",
+      "imageDate": "idk",
+      "keyCount": 75,
+      "keyboard": "IDOBO",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![IFo Hancroft Idobo Layout Image](https://i.imgur.com/ml1olw4.png)",
+      "url": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/idobo/keymaps/ifohancroft",
+      "writeup": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/idobo/keymaps/ifohancroft/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "brandonschlack",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/pai9M0m.jpg",
+      "imageDate": "idk",
+      "keyCount": 9,
+      "keyboard": "Keebio BDN9",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 9,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "brandonschlack's Macropad/Lightroom layout for BDN9",
+      "url": "https://github.com/brandonschlack/qmk_firmware/tree/master/keyboards/keebio/bdn9/keymaps/brandonschlack",
+      "writeup": "https://github.com/brandonschlack/qmk_firmware/tree/master/keyboards/keebio/bdn9/keymaps/brandonschlack/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "shadyproject",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "http://shadyproject.net/images/bfo9000-layout.png",
+      "imageDate": "idk",
+      "keyCount": 108,
+      "keyboard": "Keebio BFO-9000",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 2,
+      "split": true,
+      "stagger": "ortholinear",
+      "summary": "![Shadyproject BFO-9000 layout image](http://shadyproject.net/images/bfo9000-layout.png)",
+      "url": "https://github.com/shadyproject/qmk_firmware/tree/master/keyboards/keebio/bfo9000/keymaps/shadyproject",
+      "writeup": "https://github.com/shadyproject/qmk_firmware/tree/master/keyboards/keebio/bfo9000/keymaps/shadyproject/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "fluffactually",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/vmJSa9n.png",
+      "imageDate": "idk",
+      "keyCount": 56,
+      "keyboard": "Iris",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "columnar",
+      "summary": "Iris layout by fluffactually",
+      "url": "https://github.com/fluffactually/qmk_firmware/tree/master/keyboards/keebio/iris/keymaps/fluffactually",
+      "writeup": "https://github.com/fluffactually/qmk_firmware/tree/master/keyboards/keebio/iris/keymaps/fluffactually/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "khitsule",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/BIzu3RZ.png",
+      "imageDate": "idk",
+      "keyCount": 56,
+      "keyboard": "Iris",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": true,
+      "stagger": "columnar",
+      "summary": "Iris Layout by Khitsule",
+      "url": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/keebio/iris/keymaps/khitsule",
+      "writeup": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/keebio/iris/keymaps/khitsule/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "ardumont",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/tuk64AI.png",
+      "imageDate": "idk",
+      "keyCount": 44,
+      "keyboard": "Keyboardio Atreus",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "![ardumont layout](https://i.imgur.com/tuk64AI.png)",
+      "url": "https://github.com/ardumont/qmk_firmware/tree/master/keyboards/keyboardio/atreus/keymaps/ardumont",
+      "writeup": "https://github.com/ardumont/qmk_firmware/tree/master/keyboards/keyboardio/atreus/keymaps/ardumont/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "jwon",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/3llBswG.png",
+      "imageDate": "idk",
+      "keyCount": 86,
+      "keyboard": "Kinesis",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "row",
+      "summary": "![jwon Programmer Dvorak Layout Image](https://i.imgur.com/3llBswG.png)",
+      "url": "https://github.com/jwon/qmk_firmware/tree/master/keyboards/kinesis/keymaps/jwon",
+      "writeup": "https://github.com/jwon/qmk_firmware/tree/master/keyboards/kinesis/keymaps/jwon/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "emdarcher",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/9g3fDqL.png",
+      "imageDate": "idk",
+      "keyCount": 60,
+      "keyboard": "lattice60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "row",
+      "summary": "emdarcher's keymap for lattice60",
+      "url": "https://github.com/emdarcher/qmk_firmware/tree/master/keyboards/lattice60/keymaps/emdarcher",
+      "writeup": "https://github.com/emdarcher/qmk_firmware/tree/master/keyboards/lattice60/keymaps/emdarcher/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "drasbeck",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://drasbeck.dk/public/keymap_lily58pro_danskish.png",
+      "imageDate": "idk",
+      "keyCount": 58,
+      "keyboard": "Lily58",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "columnar",
+      "summary": "## Danish (Dansk) layout for the Lily58 Pro",
+      "url": "https://github.com/drasbeck/qmk_firmware/tree/master/keyboards/lily58/keymaps/drasbeck",
+      "writeup": "https://github.com/drasbeck/qmk_firmware/tree/master/keyboards/lily58/keymaps/drasbeck/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "khitsule",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/bEdqotb.png",
+      "imageDate": "idk",
+      "keyCount": 36,
+      "keyboard": "MiniDox",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "row",
+      "summary": "Minidox Layout by Khitsule",
+      "url": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/minidox/keymaps/khitsule",
+      "writeup": "https://github.com/khitsule/qmk_firmware/tree/master/keyboards/minidox/keymaps/khitsule/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "brandonschlack",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/08759vK.png",
+      "imageDate": "idk",
+      "keyCount": 49,
+      "keyboard": "Nightmare",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 8,
+      "split": false,
+      "stagger": "row",
+      "summary": "brandonschlack's Nightmare Keymap",
+      "url": "https://github.com/brandonschlack/qmk_firmware/tree/master/keyboards/nightmare/keymaps/brandonschlack",
+      "writeup": "https://github.com/brandonschlack/qmk_firmware/tree/master/keyboards/nightmare/keymaps/brandonschlack/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "rfvizarra",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/RQ5SKj4.jpg",
+      "imageDate": "idk",
+      "keyCount": 46,
+      "keyboard": "Monkeebs Orthodox Rev.1",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 9,
+      "split": true,
+      "stagger": "columnar",
+      "summary": "A personal Orthodox Layout",
+      "url": "https://github.com/rfvizarra/qmk_firmware/tree/master/keyboards/orthodox/keymaps/rfvizarra",
+      "writeup": "https://github.com/rfvizarra/qmk_firmware/tree/master/keyboards/orthodox/keymaps/rfvizarra/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "dbroqua",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/XxBtDBy.png",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "Dbroqua Layout",
+      "url": "https://github.com/dbroqua/qmk_firmware/tree/master/keyboards/planck/keymaps/dbroqua",
+      "writeup": "https://github.com/dbroqua/qmk_firmware/tree/master/keyboards/planck/keymaps/dbroqua/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "eshesh2",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/eVgHH6k.png",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![eshesh2's Planck Layout](https://i.imgur.com/eVgHH6k.png)",
+      "url": "https://github.com/eshesh2/qmk_firmware/tree/master/keyboards/planck/keymaps/eshesh2",
+      "writeup": "https://github.com/eshesh2/qmk_firmware/tree/master/keyboards/planck/keymaps/eshesh2/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "fsck",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/GOLyPGP.png",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![preonic:fsck Layout Image](https://i.imgur.com/GOLyPGP.png)",
+      "url": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/planck/keymaps/fsck",
+      "writeup": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/planck/keymaps/fsck/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "ishtob",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/yKewjWW.jpg",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 10,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![Planck Layout Image](https://i.imgur.com/yKewjWW.jpg)",
+      "url": "https://github.com/ishtob/qmk_firmware/tree/master/keyboards/planck/keymaps/ishtob",
+      "writeup": "https://github.com/ishtob/qmk_firmware/tree/master/keyboards/planck/keymaps/ishtob/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS",
+        "GNU+Linux"
+      ],
+      "author": "rjhilgefort",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/elygxAb.jpg",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "[\ud83d\udc26 @rjhilgefort](https://twitter.com/rjhilgefort) Planck Layout",
+      "url": "https://github.com/rjhilgefort/qmk_firmware/tree/master/keyboards/planck/keymaps/rjhilgefort",
+      "writeup": "https://github.com/rjhilgefort/qmk_firmware/tree/master/keyboards/planck/keymaps/rjhilgefort/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "rootiest",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://github.com/rootiest/rootiest.github.io/raw/main/img/rootiest-planck_legend.png",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 10,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "",
+      "url": "https://github.com/rootiest/qmk_firmware/tree/master/keyboards/planck/keymaps/rootiest",
+      "writeup": "https://github.com/rootiest/qmk_firmware/tree/master/keyboards/planck/keymaps/rootiest/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "yhaliaw",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/HvYva64.png",
+      "imageDate": "idk",
+      "keyCount": 48,
+      "keyboard": "Planck",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "yhaliaw Planck layout",
+      "url": "https://github.com/yhaliaw/qmk_firmware/tree/master/keyboards/planck/keymaps/yhaliaw",
+      "writeup": "https://github.com/yhaliaw/qmk_firmware/tree/master/keyboards/planck/keymaps/yhaliaw/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "rfvizarra",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/K7ONE1k.jpg",
+      "imageDate": "idk",
+      "keyCount": 67,
+      "keyboard": "pk60",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 3,
+      "split": false,
+      "stagger": "row",
+      "summary": "A personal keymap for Play Keyboard60 based on the minila layout",
+      "url": "https://github.com/rfvizarra/qmk_firmware/tree/master/keyboards/playkbtw/pk60/keymaps/rfvizarra",
+      "writeup": "https://github.com/rfvizarra/qmk_firmware/tree/master/keyboards/playkbtw/pk60/keymaps/rfvizarra/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "fsck",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/nI8fBco.png",
+      "imageDate": "idk",
+      "keyCount": 60,
+      "keyboard": "Preonic",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "![preonic:fsck Layout Image](https://i.imgur.com/nI8fBco.png)",
+      "url": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/preonic/keymaps/fsck",
+      "writeup": "https://github.com/fsck/qmk_firmware/tree/master/keyboards/preonic/keymaps/fsck/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "shwilliam",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://user-images.githubusercontent.com/38357771/84585088-dc536380-adc0-11ea-8378-6fb8ffbc6a8d.png",
+      "imageDate": "idk",
+      "keyCount": 60,
+      "keyboard": "Preonic",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "ortholinear",
+      "summary": "[@shwilliam](https://github.com/shwilliam)'s Preonic Layout",
+      "url": "https://github.com/shwilliam/qmk_firmware/tree/master/keyboards/preonic/keymaps/shwilliam",
+      "writeup": "https://github.com/shwilliam/qmk_firmware/tree/master/keyboards/preonic/keymaps/shwilliam/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "fculpo",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/OXT8boJ.png",
+      "imageDate": "idk",
+      "keyCount": 70,
+      "keyboard": "Redox",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "row",
+      "summary": "A tweaked keymap for Redox",
+      "url": "https://github.com/fculpo/qmk_firmware/tree/master/keyboards/redox/keymaps/fculpo",
+      "writeup": "https://github.com/fculpo/qmk_firmware/tree/master/keyboards/redox/keymaps/fculpo/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "nrichers",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://github.com/nrichers/qmk_firmware/blob/master/keyboards/redox/keymaps/nrichers/keymap.png",
+      "imageDate": "idk",
+      "keyCount": 70,
+      "keyboard": "Redox",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": true,
+      "stagger": "row",
+      "summary": "A tweaked keymap for Redox",
+      "url": "https://github.com/nrichers/qmk_firmware/tree/master/keyboards/redox/keymaps/nrichers",
+      "writeup": "https://github.com/nrichers/qmk_firmware/tree/master/keyboards/redox/keymaps/nrichers/readme.md"
+    },
+    {
+      "OS": [
+        "Windows",
+        "MacOS",
+        "GNU+Linux"
+      ],
+      "author": "josefadamcik",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/1w2OA1o.png",
+      "imageDate": "idk",
+      "keyCount": 70,
+      "keyboard": "Katana60 rev1",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 8,
+      "split": false,
+      "stagger": "row",
+      "summary": "![Multi OS Katana60 layout image](https://i.imgur.com/1w2OA1o.png)",
+      "url": "https://github.com/josefadamcik/qmk_firmware/tree/master/keyboards/rominronin/katana60/rev1/keymaps/josefadamcik",
+      "writeup": "https://github.com/josefadamcik/qmk_firmware/tree/master/keyboards/rominronin/katana60/rev1/keymaps/josefadamcik/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "encg",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/rUc3IOn.gif",
+      "imageDate": "idk",
+      "keyCount": 2,
+      "keyboard": "2% Milk",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 1,
+      "split": false,
+      "stagger": "columnar",
+      "summary": "encg's Keymap",
+      "url": "https://github.com/encg/qmk_firmware/tree/master/keyboards/spaceman/2_milk/keymaps/encg",
+      "writeup": "https://github.com/encg/qmk_firmware/tree/master/keyboards/spaceman/2_milk/keymaps/encg/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "raylas",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/cV9niMC.jpg",
+      "imageDate": "idk",
+      "keyCount": 68,
+      "keyboard": "Tada68",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 2,
+      "split": false,
+      "stagger": "row",
+      "summary": "![TADA68 layout image](https://i.imgur.com/cV9niMC.jpg)",
+      "url": "https://github.com/raylas/qmk_firmware/tree/master/keyboards/tada68/keymaps/raylas",
+      "writeup": "https://github.com/raylas/qmk_firmware/tree/master/keyboards/tada68/keymaps/raylas/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "smt",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/Y4n6eHj.png",
+      "imageDate": "idk",
+      "keyCount": 45,
+      "keyboard": "tv44",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 6,
+      "split": false,
+      "stagger": "row",
+      "summary": "smt's TV44 keymap",
+      "url": "https://github.com/smt/qmk_firmware/tree/master/keyboards/thevankeyboards/minivan/keymaps/smt",
+      "writeup": "https://github.com/smt/qmk_firmware/tree/master/keyboards/thevankeyboards/minivan/keymaps/smt/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "annihilator6000",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/lICX4uz.png",
+      "imageDate": "idk",
+      "keyCount": 47,
+      "keyboard": "UT47.2",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 9,
+      "split": false,
+      "stagger": "row",
+      "summary": "UT47.2 Planck-style layout switching",
+      "url": "https://github.com/annihilator6000/qmk_firmware/tree/master/keyboards/ut472/keymaps/annihilator6000",
+      "writeup": "https://github.com/annihilator6000/qmk_firmware/tree/master/keyboards/ut472/keymaps/annihilator6000/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "ifohancroft",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/3BGQS75.png",
+      "imageDate": "idk",
+      "keyCount": 61,
+      "keyboard": "V60 Type R",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 4,
+      "split": false,
+      "stagger": "row",
+      "summary": "![IFo Hancroft KBParadise V60 Type R Layout Image](https://i.imgur.com/3BGQS75.png)",
+      "url": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/v60_type_r/keymaps/ifohancroft",
+      "writeup": "https://github.com/ifohancroft/qmk_firmware/tree/master/keyboards/v60_type_r/keymaps/ifohancroft/readme.md"
+    },
+    {
+      "OS": [],
+      "author": "dudeofawesome",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/TYYqJbP.png",
+      "imageDate": "idk",
+      "keyCount": 68,
+      "keyboard": "Whitefox",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "row",
+      "summary": "DudeOfAwesome's WhiteFox layout",
+      "url": "https://github.com/dudeofawesome/qmk_firmware/tree/master/keyboards/whitefox/keymaps/dudeofawesome",
+      "writeup": "https://github.com/dudeofawesome/qmk_firmware/tree/master/keyboards/whitefox/keymaps/dudeofawesome/readme.md"
+    },
+    {
+      "OS": [
+        "MacOS"
+      ],
+      "author": "emdarcher",
+      "firmware": "QMK",
+      "hasExtraIndexColumns": false,
+      "hasHomeRowMods": false,
+      "hasLetterOnThumb": false,
+      "hasOuterPinkyColumns": true,
+      "hasVerticalCombos": false,
+      "image": "https://i.imgur.com/ie5aF7d.jpg",
+      "imageDate": "idk",
+      "keyCount": 62,
+      "keyboard": "YMDK Bface",
+      "languages": [
+        "English"
+      ],
+      "layerCount": 5,
+      "split": false,
+      "stagger": "row",
+      "summary": "emdarcher's keymap",
+      "url": "https://github.com/emdarcher/qmk_firmware/tree/master/keyboards/ymdk/bface/keymaps/emdarcher",
+      "writeup": "https://github.com/emdarcher/qmk_firmware/tree/master/keyboards/ymdk/bface/keymaps/emdarcher/readme.md"
+    }
+  ]
+}


### PR DESCRIPTION
I created a list of keymap candidates with this multi-command:
```sh
cd ~/qmk_firwmare | ls **/keymaps/**/readme.md | sed "/default\/readme.md/d" | xargs grep -E -c '!\[.*\]\(.*\.(jpe?g|png)( ".*")?\)' | grep "1$"  | sed "s/1$//" > candidate_keymap_folders.txt
```
Next, I filtered that list to only get keymaps whose folder names are real GitHub usernames which I stored as a List[Tuple[str, str]] in `kbs_authors.py`

```py
import json
import requests
import subprocess
from typing import Tuple, List
import re
from kbs_authors import kbs_authors # needs to be generated first
import os
from math import floor
from itertools import compress

path_pattern = re.compile("^keyboards/(.*)/keymaps/(.*)/$", flags=re.MULTILINE|re.UNICODE)

with open("candidate_keymap_folders.txt", "r") as f:
    folder_paths: str = f.read()
    kbs_names: List[Tuple[str, str]] = re.findall(path_pattern, folder_paths)


# Run the below code once to filter keymaps whose folder names is a real GitHub username.
# (Some keymaps are named "french" etc. so we can't assume the folder name to always be that of the author)
#
# def is_real_github_username(kb_username) -> bool:
    # keyboard_name, username = kb_username
    # response = requests.get(f"https://github.com/{username}/qmk_firmware/tree/master/keyboards/{keyboard_name}/keymaps/{username}")
    # print(f"{response=}")
    # return bool(response)

# filtered_kbs_names = filter(is_real_github_username, kbs_names)
# with open("kbs_authors.py", "w") as f:
    # f.write("kbs_authors = " + str(list(filtered_kbs_names)))

def get_folder_path(keyboard_name, username) -> str:
    return f"/home/vern/qmk_firmware/keyboards/{keyboard_name}/keymaps/{username}/"

def get_image_link(kb_username) -> str:
    keyboard_name, username = kb_username
    path = get_folder_path(keyboard_name, username)
    md_image_pattern = re.compile(r'!\[.*\]\((.*\.[a-z]+)(?: ".*")?\)')
    with open(path + "readme.md", "r") as readme_file:
        image_link = re.findall(md_image_pattern, readme_file.read())[0]
    return image_link

def get_layout_macro_name(kb_info, keyboard_name, username) -> str:
    # Note: `kb_info["keyboard_folder"]` isn't always the same as `keyboard_name`
    # For example, the keyboard folder for the Atreus is said to be "atreus/astar"
    with open(get_folder_path(keyboard_name, username) + "keymap.c", "r") as f:
        keymapdotc = f.read()
    # Important to go through the longest layout macro names first because there are
    # many layout macro names that start the same 
    # (e.g. LAYOUT_60_ansi, LAYOUT_60_ansi_split_rshift)
    layout_macros = sorted(kb_info["layouts"].keys(), key=len, reverse=True)
    for possible_layout in layout_macros:
        if possible_layout in keymapdotc:
            return possible_layout
    return tuple(kb_info["layouts"].keys())[0]

def get_key_count(kb_info, keyboard_name, username) -> int:
    layout = get_layout_macro_name(kb_info, keyboard_name, username)
    return kb_info["layouts"][layout]["key_count"]

def get_OS(readme: str) -> List[str]:
    windows_pattern = re.compile("Windows", flags=re.IGNORECASE)
    mac_pattern = re.compile("Mac(?:OS)?", flags=re.IGNORECASE)
    linux_pattern = re.compile("(?:GNU[\+/ ])?Linux", flags=re.IGNORECASE)
    os_patterns = [windows_pattern, mac_pattern, linux_pattern]
    os_categories = ["Windows", "MacOS", "GNU+Linux"]
    os_mask = [bool(re.search(pattern, readme)) for pattern in os_patterns]
    return list(compress(os_categories, os_mask))

def get_stagger(kb_info, layout) -> str:
    # Assume ortholinearity, change assumption if decimal x or y values are found.
    stagger_type = "ortholinear"

    # Dactyl, Dactyl Manuform, Tractyl, Pterodactyl, ...
    if "actyl" in kb_info["keyboard_name"]:
        return "depth"

    last_x: int = 0
    last_y: float = 0
    # I hate how frequently QMK uses the word "layout" as a key in the JSON
    for keyboard_key in kb_info["layouts"][layout]["layout"]: 
        x: int = keyboard_key[ "x" ]
        y: float = keyboard_key[ "y" ]
        if not isinstance(x, int):
            stagger_type = "row"
        # if the current keyboard_key is to the left of the last one,
        # that has to mean that it is on another row.
        if floor(x) >= last_x:
            if y != last_y:
                stagger_type = "columnar"
        last_x = x
        last_y = y

    return stagger_type

def has_home_row_mods(keymapdotc) -> bool:
    # Every alpha layout I have ever come across had A *and* S on their home row 
    # with the exception of AZERTY which only has S on its home row.
    mt_a_pattern = re.compile("MT\(\s*MOD_[A-Z]+,\s*[A-Z][A-Z]_A\)|(L|R)?\w{2,3}_T\([A-Z][A-Z]_A\)")
    mt_s_pattern = re.compile("MT\(\s*MOD_[A-Z]+,\s*[A-Z][A-Z]_S\)|(L|R)?\w{2,3}_T\([A-Z][A-Z]_S\)")
    return bool(re.search(mt_a_pattern, keymapdotc)) and bool(re.search(mt_s_pattern, keymapdotc)) 


headers = ["url", "author", "image", "keyCount", "firmware", "keyboard", "stagger", "split", "languages", "summary", "OS", "writeup", "hasLetterOnThumb", "layerCount", "imageDate", "hasOuterPinkyColumns", "hasExtraIndexColumns", "hasVerticalCombos", "hasHomeRowMods"]
def get_keymapdb_entry(kb_username) -> dict:
    print(f"Adding {kb_username=} to the database.")

    # Set up variables
    keyboard_name, username = kb_username
    entry: dict = {}
    rev: str = ""
    if os.path.isdir(f"/home/vern/qmk_firmware/keyboards/{keyboard_name}/rev1/"):
        rev = "/rev1"
    qmk_info_output = subprocess.check_output(["qmk", "info", "-kb", keyboard_name + rev, "-m", "-f", "json"])
    kb_info: dict = json.loads(qmk_info_output)
    layout: str = get_layout_macro_name(kb_info, keyboard_name, username)
    print(f"The layout macro for this board is {layout}.")
    path = get_folder_path(keyboard_name, username)
    with open(path + "readme.md", "r") as readme_file:
        readme: str = readme_file.read()
    with open(path + "keymap.c", "r") as keymapdotc_file:
        keymapdotc: str = keymapdotc_file.read()

    # Populate the db fields
    entry["url"] = f"https://github.com/{username}/qmk_firmware/tree/master/keyboards/{keyboard_name}/keymaps/{username}"
    entry["author"] = username
    entry["image"] = get_image_link(kb_username)
    entry["keyCount"] = get_key_count(kb_info, keyboard_name, username)
    entry["firmware"] = "QMK"
    entry["keyboard"] = kb_info["keyboard_name"]
    entry["stagger"] = get_stagger(kb_info, layout)
    if "split" in kb_info and "enabled" in kb_info["split"]:
        entry["split"] = kb_info["split"]["enabled"]
    else:
        entry["split"] = False
    entry["languages"] = ["English"]
    # Use the title of the keymap readme for the summary (but strip the md header #)
    entry["summary"] = re.sub("^# ", "", readme[:readme.find("\n")])
    entry["OS"] = get_OS(readme)
    entry["writeup"] = f"https://github.com/{username}/qmk_firmware/tree/master/keyboards/{keyboard_name}/keymaps/{username}/readme.md"
    entry["hasLetterOnThumb"] = False # might be wrong
    # Remove any commented out layer templates before counting the number of layers
    # This technique doesn't work for old keymaps which don't use any layout macros like maxr1998's
    entry["layerCount"] = re.sub("/?\*.*LAYOUT", "", keymapdotc).count("LAYOUT")
    assert entry["layerCount"] > 0
    entry["imageDate"] = "idk"
    # TODO rules.mk options
    entry["hasOuterPinkyColumns"] = True # most likely but might be wrong
    entry["hasExtraIndexColumns"] = False # not likely but might be wrong
    entry["hasVerticalCombos"] = False # not likely but might be wrong
    entry["hasHomeRowMods"] = has_home_row_mods(keymapdotc)
    assert set(entry.keys()) == set(headers), f"{set(entry.keys())=}\n{ set(headers)=}"
    return entry

keymapdb = tuple(map(get_keymapdb_entry, kbs_authors))
print(keymapdb)

data = {"headers": headers, "keymaps": keymapdb}
with open("new_data.json", "w") as new_data_f:
    new_data_f.write(json.dumps(data, sort_keys=True, indent=2))

```
PS: Don't judge the code too much, 'tis just a "quick" script I wrote